### PR TITLE
fix readme and cargo config

### DIFF
--- a/hestia-sat/.cargo/config.toml
+++ b/hestia-sat/.cargo/config.toml
@@ -2,5 +2,5 @@
 target = ["arm-unknown-linux-gnueabihf", "aarch64-apple-darwin"]
 
 [target.arm-unknown-linux-gnueabihf]
-linker = "/Users/mryall/bin/arm-linux-gcc" # linker must be on PATH
+linker = "arm-linux-gcc" # linker must be on PATH
 runner = "./upload.sh"

--- a/hestia-sat/README.md
+++ b/hestia-sat/README.md
@@ -14,7 +14,7 @@ It will fail until you have correctly set up the cross-compiler for the BBB.
 
 * Add the target for your Rust environment with: 
   `rustup target add arm-unknown-linux-gnueabihf`
-* Install the ARM Linux cross-compiler `arm-unknown-linux-gnueabi` from
+* Install the ARM Linux cross-compiler `arm-unknown-linux-gnueabihf` from
   [osx-arm-linux-toolchains](https://github.com/thinkski/osx-arm-linux-toolchains), and symlink
   the `bin/arm-unknown-linux-gnueabihf-gcc` command to your PATH as `arm-linux-gcc`. (It needs to match the
   linker configuration in `.cargo/config.toml`.)


### PR DESCRIPTION
* refer to correct toolchain in readme file
* just use the linker name and not an absolute path in config.toml