### PR TITLE
#73 Compress log files

### DIFF
--- a/hestia-sat/Cargo.lock
+++ b/hestia-sat/Cargo.lock
@@ -458,6 +458,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2359,6 +2380,7 @@ dependencies = [
  "assert_approx_eq",
  "bincode",
  "byteorder",
+ "bzip2",
  "chrono",
  "clap",
  "colored",

--- a/hestia-sat/Cargo.toml
+++ b/hestia-sat/Cargo.toml
@@ -36,6 +36,7 @@ tempfile = "3.8.0"
 reqwest = "0.11.20"
 openssl = { version = "0.10.57", features = ["vendored"] }
 syslog = "6.1.0"
+bzip2 = "0.4"
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0"

--- a/hestia-sat/README.md
+++ b/hestia-sat/README.md
@@ -63,6 +63,7 @@ The Hestia binaries can be configured by setting the following environment varia
 | variable            | default | description                                                                      |
 |---------------------|---------|----------------------------------------------------------------------------------|
 | `UTS_LOG_PATH`      |         | Log file directory                                                               |
+| `UTS_COMPRESS_LOGS` | `false` | Use bzip2 compression when writing logs                                                               |
 | `UTS_I2C_BUS`       | `1,2`   | List of active I2C bus numbers                                                   |
 | `UTS_BOARD_VERSION` | `V2_2`  | Board version, used for switching some address settings [`V1_1`, `V2_0`, `V2_2`] |
 | `UTS_LOG_INTERVAL`  | `5`     | Duration between logging output in seconds                                       |

--- a/hestia-sat/src/bin/uts-log/main.rs
+++ b/hestia-sat/src/bin/uts-log/main.rs
@@ -19,7 +19,7 @@ fn loop_logger_for_day(config: &Config) {
     let payload = Payload::from_config(config);
     info!("Configured with {} boards: {:?}", payload.iter().len(), payload.iter());
 
-    let mut writer = LogWriter::create_file_writer(log_path, &payload, &start_date);
+    let mut writer = LogWriter::create_file_writer(log_path, &payload, &start_date, config.compress_logs);
     writer.write_header_if_new();
 
     loop {

--- a/hestia-sat/src/logger.rs
+++ b/hestia-sat/src/logger.rs
@@ -38,7 +38,7 @@ impl<'a> LogWriter<'a> {
                   if raw_log { "raw" } else { "temp" },
                   file_path.display());
         let is_new = !file_path.exists();
-        return if compressed {
+        if compressed {
             CsvWriter::compressed_file(file_path, is_new)
         } else {
             CsvWriter::file(file_path, is_new)

--- a/hestia-sat/src/logger.rs
+++ b/hestia-sat/src/logger.rs
@@ -29,9 +29,10 @@ impl<'a> LogWriter<'a> {
     }
 
     fn new_csv_writer(start_date: &DateTime<Utc>, log_path: &Path, raw_log: bool, compressed: bool) -> CsvWriter {
-        let filename = &format!("uts-data-{}{}.csv",
+        let filename = &format!("uts-data-{}{}.csv{}",
                                 start_date.format("%Y-%m-%d"),
-                                if raw_log { "-raw" } else { "" });
+                                if raw_log { "-raw" } else { "" },
+                                if compressed { ".bz2" } else { "" });
         let file_path = log_path.join(filename);
         info!("Logging {} sensor data to {}...",
                   if raw_log { "raw" } else { "temp" },

--- a/hestia-sat/src/payload.rs
+++ b/hestia-sat/src/payload.rs
@@ -20,6 +20,9 @@ pub struct Config {
     /// Log file directory
     pub log_path: Option<String>,
 
+    #[serde(default)]
+    pub compress_logs: bool,
+
     /// List of active I2C bus numbers
     #[serde(default = "default_i2c_bus")]
     pub i2c_bus: Vec<u8>,


### PR DESCRIPTION
First cut at this implementation. Log files will be compressed using bzip2 when the UTS_COMPRESS_LOGS option is set.

Still to do: check appending to existing logs; rename files to use .bzip2 extension.